### PR TITLE
VS Code workspace changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "deno.enable": true
+    "deno.enable": true,
+    "deno.lint": true,
+    "editor.defaultFormatter": "denoland.vscode-deno",
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Updates the `.vscode/settings.json` to enable Deno linting, to use Deno as the default formatter, and to auto-format code on save. This fixes issues with renaming variable names with `F2` and ensures code formatting stays consistent throughout the code base.